### PR TITLE
Fix serialize is not a function in treeview

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -196,7 +196,11 @@ module.exports = {
 
         treeview = require(treeview.mainModulePath);
 
-        var package_obj = treeview.treeView.serialize();
+        var package_obj = treeview.serialize();
+
+        if (!package_obj)
+          package_obj = treeview.treeview.serialize();
+          
         var file_path = package_obj.selectedPath;
 
         this.set_flow_file( file_path );

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -196,7 +196,7 @@ module.exports = {
 
         treeview = require(treeview.mainModulePath);
 
-        var package_obj = treeview.serialize();
+        var package_obj = treeview.treeView.serialize();
         var file_path = package_obj.selectedPath;
 
         this.set_flow_file( file_path );


### PR DESCRIPTION
Update to reflect recent changes in the atom-treeview package.

fixes #17 
