### PR TITLE
Fix tree serialise error and formatting of atom-message-panel require

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -195,12 +195,11 @@ module.exports = {
         if(!treeview) return;
 
         treeview = require(treeview.mainModulePath);
+        if(!treeview.serialize)
+          treeview = treeview.getTreeViewInstance();
 
         var package_obj = treeview.serialize();
 
-        if (!package_obj)
-          package_obj = treeview.treeview.serialize();
-          
         var file_path = package_obj.selectedPath;
 
         this.set_flow_file( file_path );

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,8 +1,8 @@
 
-            //atom built in
-    var   atom_panels = require('atom-message-panel')
-        , MessagePanelView = atom_panels.MessagePanelView
-        , PlainMessageView = atom_panels.PlainMessageView
+//atom built in
+var   atom_panels = require('atom-message-panel')
+    , MessagePanelView = atom_panels.MessagePanelView
+    , PlainMessageView = atom_panels.PlainMessageView
 
 module.exports = {
 


### PR DESCRIPTION
More robust way of requesting the treeview instance (it could change in the future).

Tested locally on Mac, Windows and Linux. Atom versions 18 and 22.
