### PR TITLE
 Replace "flow" with "flõw" in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # atom-flow
-atom.io support for haxe flow build tool
+atom.io support for haxe flõw build tool
 http://snowkit.org/flow
 
 ## Active development

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "main": "./lib/flow.js",
   "version": "0.5.3",
-  "description": "atom.io support for the haxe flow build tool.",
+  "description": "atom.io support for the haxe flõw build tool.",
   "activationCommands": {},
   "consumedServices": {
     "haxe-completion.provider": {


### PR DESCRIPTION
When browsing for Atom packages, users looking for tools for facebook's flowtype are likely to search for "flow" and install this plugin. Using flõw where Unicode characters are possible avoids that confusion.